### PR TITLE
Add OpenPaw

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,8 @@ Key stats:
 
 - **[Openwork](https://github.com/accomplish-ai/openwork)** — MIT-licensed open alternative to Anthropic's Cowork with multi-LLM support for browser automation.
 
+- **[OpenPaw](https://github.com/daxaur/openpaw)** — Turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more. One command (`npx pawmode`) to install. No daemon, no cloud, MIT license.
+
 #### 🦞 Awesome OpenClaw Resources
 
 - **[Awesome OpenClaw Skills](https://github.com/VoltAgent/awesome-openclaw-skills)** — Community registry of 5,700+ skills for OpenClaw


### PR DESCRIPTION
OpenPaw turns Claude Code into a personal assistant with 38 skills covering email, calendar, Spotify, smart home, Slack, GitHub, Obsidian, and more. Single command to install (`npx pawmode`), no daemon, no cloud, MIT licensed.

Fits well in the Self-Hosted & Local AI Agents section since it runs entirely locally through the user's existing Claude Code setup.

- **Repo:** https://github.com/daxaur/openpaw
- **npm:** https://www.npmjs.com/package/pawmode