### PR TITLE
Add DataRaven to Data Pipeline & Workflow Orchestration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -347,7 +347,7 @@ Key stats:
 
 - **[Dagster](https://dagster.io/)** — Data orchestration built around software-defined assets. Strong observability and testing support.
 
-- **[DataRaven](https://dataraven.io/)** — Cloud-agnostic data pipeline and transfer orchestration for object storage across S3, GCS, Azure Blob, R2, and more.
+- **[DataRaven](https://dataraven.io/)** — Managed rclone for cloud object storage.
 
 - **[Kestra](https://kestra.io/)** — Open-source declarative workflow orchestration. YAML-based, 500+ plugins, cloud-native.
 

--- a/readme.md
+++ b/readme.md
@@ -347,6 +347,8 @@ Key stats:
 
 - **[Dagster](https://dagster.io/)** — Data orchestration built around software-defined assets. Strong observability and testing support.
 
+- **[DataRaven](https://dataraven.io/)** — Cloud-agnostic data pipeline and transfer orchestration for object storage across S3, GCS, Azure Blob, R2, and more.
+
 - **[Kestra](https://kestra.io/)** — Open-source declarative workflow orchestration. YAML-based, 500+ plugins, cloud-native.
 
 - **[Apache Kafka](https://kafka.apache.org/)** — Distributed event streaming platform. Foundation for real-time data pipelines and event-driven automation.

--- a/readme.md
+++ b/readme.md
@@ -347,7 +347,7 @@ Key stats:
 
 - **[Dagster](https://dagster.io/)** — Data orchestration built around software-defined assets. Strong observability and testing support.
 
-- **[DataRaven](https://dataraven.io/)** — Managed rclone for cloud object storage.
+- **[DataRaven](https://dataraven.io/)** — Managed rclone for scheduled cloud object storage workflows.
 
 - **[Kestra](https://kestra.io/)** — Open-source declarative workflow orchestration. YAML-based, 500+ plugins, cloud-native.
 


### PR DESCRIPTION
Adds DataRaven to the **Data Pipeline & Workflow Orchestration** section.

Why this section:
- DataRaven is used for data pipeline transfer orchestration and scheduled movement workflows.
- It is specifically relevant to object-storage pipelines (S3, GCS, Azure Blob, R2, etc.).

Kept as one concise line in the repository format.