### PR TITLE
Add Lumen - vision-first browser agent

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -255,6 +255,8 @@ Key stats:
 
 - **[Stagehand](https://www.stagehand.dev/)** ⭐ 5K+ stars — AI-native Playwright wrapper. Adds LLM reasoning on top of deterministic Playwright scripting. Built and maintained by Browserbase.
 
+- **[Lumen](https://github.com/omxyz/lumen)** — Vision-first browser agent with self-healing deterministic replay over CDP. Screenshot → model → action loop with multi-provider support (Anthropic, Google). TypeScript, MIT licensed.
+
 - **[Playwright MCP](https://github.com/microsoft/playwright-mcp)** ⭐ 10K+ stars — Microsoft's MCP server for AI-controlled browser automation. Uses the accessibility tree (Snapshot Mode) — no screenshots needed, fast and deterministic.
 
 - **[Perplexity Comet](https://www.perplexity.ai/comet)** — Consumer AI browser (Chromium-based). Autonomous navigation, form filling, email and calendar management, voice control. Launched July 2025.


### PR DESCRIPTION
## What is Lumen?

[Lumen](https://github.com/omxyz/lumen) is a vision-first browser agent with self-healing deterministic replay over CDP.

- **Screenshot → model → action loop** over Chrome DevTools Protocol
- **Self-healing action cache** for deterministic replay
- **Multi-provider support** (Anthropic, Google)
- TypeScript · MIT · [npm](https://www.npmjs.com/package/@omxyz/lumen) · [Docs](https://lumen.omlabs.xyz)