### PR TITLE
Add EnrichAnything Public API resource

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -472,6 +472,7 @@ Key stats:
 - 📊 [**AI Coding Agent Benchmarks**](https://github.com/murataslan1/ai-agent-benchmark) — SWE-Bench leaderboard, pricing, real user reviews
 - 🤖 [**AI Agentic Frameworks Guide**](https://www.agentically.sh/ai-agentic-frameworks/) — Comprehensive framework comparison
 - 📦 [**Product Hunt: AI Agent Automation**](https://www.producthunt.com/categories/ai-agent-automation) — Latest AI agent launches
+- 🧾 [**EnrichAnything Public API**](https://www.enrichanything.com/api/) — Source-backed market scans and report summaries as structured JSON for prospecting and internal automation workflows
 - 🌐 [**Firecrawl Blog**](https://www.firecrawl.dev/blog) — Browser agent guides and web automation news
 
 ---


### PR DESCRIPTION
Adds EnrichAnything Public API under Resources & Directories.

Reason for fit:
- it is a workflow resource, not a generic marketing tool
- the public API serves structured JSON market scans and report summaries
- the docs are directly usable inside internal prospecting and ops workflows

Docs: https://www.enrichanything.com/api/
OpenAPI: https://www.enrichanything.com/openapi.json