### PR TITLE
Add Safari MCP

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -257,6 +257,8 @@ Key stats:
 
 - **[Playwright MCP](https://github.com/microsoft/playwright-mcp)** ⭐ 10K+ stars — Microsoft's MCP server for AI-controlled browser automation. Uses the accessibility tree (Snapshot Mode) — no screenshots needed, fast and deterministic.
 
+- **[Safari MCP](https://github.com/achiya-automation/safari-mcp)** — Native Safari browser automation for AI agents. 80 tools via AppleScript, zero Chrome overhead, keeps logins. macOS-native MCP server.
+
 - **[Perplexity Comet](https://www.perplexity.ai/comet)** — Consumer AI browser (Chromium-based). Autonomous navigation, form filling, email and calendar management, voice control. Launched July 2025.
 
 ### Browser Infrastructure


### PR DESCRIPTION
## Summary
- Adds [Safari MCP](https://github.com/achiya-automation/safari-mcp) to the "AI Browser Agents" section
- Native Safari browser automation for AI agents on macOS — 80 tools via AppleScript + JavaScript, zero Chrome overhead, keeps all logins
- MIT licensed, MCP server, available on npm as `safari-mcp`

## Checklist
- [x] Entry follows existing bold format (`- **[Name](url)** — Description.`)
- [x] Placed in AI Browser Agents section (alphabetically between "Playwright MCP" and "Perplexity Comet")
- [x] Project is a browser automation tool for AI agents