### PR TITLE
Add Appy Pie Automate to Classic Automation & iPaaS section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -94,6 +94,8 @@ Key stats:
 
 - **[Kissflow](https://kissflow.com/)** — Low-code platform with AI natural language workflow creation and predictive workflow optimization.
 
+- **[Appy Pie Automate](https://appypieautomate.ai/)** — No-code workflow automation platform with 1,000+ app integrations. Connect Gmail, Slack, Shopify, HubSpot, Salesforce, and more — without writing code. Trusted by 10M+ users worldwide.
+
 ---
 
 ## 🧠 AI-Powered Automation Platforms


### PR DESCRIPTION
Adds **Appy Pie Automate** (https://appypieautomate.ai/) to the Classic Automation & iPaaS section.

**Why it belongs here:**
- No-code workflow automation platform — direct alternative to Zapier and Make
- 1,000+ app integrations (Gmail, Slack, Shopify, HubSpot, Salesforce, and more)
- Trusted by 10M+ users worldwide
- Actively maintained with regular updates
- Full documentation at https://helpdesk.appypieautomate.ai/

Follows the contributing guidelines format.