### PR TITLE
Add Xquik and remove retired Automate.io listing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -124,6 +124,8 @@ Key stats:
 
 - **[Agent Builder](https://productivity.directory/agent-builder)** — *[Review](https://productivity.directory/agent-builder)* — Build your own custom AI assistants with OpenAI's no-code Agent Builder.
 
+- **[Xquik](https://xquik.com/)** - X (Twitter) automation platform with 40+ REST API endpoints, MCP server for AI agents, HMAC webhooks, and real-time monitoring.
+
 ---
 
 ## 🤖 AI Agent Platforms

--- a/readme.md
+++ b/readme.md
@@ -82,8 +82,6 @@ Key stats:
 
 - **[Tray.io](https://tray.io/)** — *[Review](https://productivity.directory/tray-io)* — Enterprise-grade low-code automation builder with AI orchestration.
 
-- **[Automate.io](https://automate.io/)** — *[Review](https://productivity.directory/automate-io)* — Integrate apps and automate business workflows.
-
 - **[Albato](https://albato.com/)** — No-code automation platform for connecting apps without technical expertise.
 
 - **[Node-RED](https://nodered.org/)** — Low-code event-driven programming for IoT and workflow automation. Open-source, browser-based flow editor.
@@ -123,6 +121,10 @@ Key stats:
 - **[Wordware](https://www.wordware.ai/)** — AI agent builder using natural language. Teams can build and share agents without writing code.
 
 - **[Agent Builder](https://productivity.directory/agent-builder)** — *[Review](https://productivity.directory/agent-builder)* — Build your own custom AI assistants with OpenAI's no-code Agent Builder.
+
+- **[Xquik](https://xquik.com/)** - X automation platform with a REST API, MCP server for AI agents, HMAC webhooks, and real-time monitoring.
+
+  Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
 
 ---
 


### PR DESCRIPTION
## Summary

- Add Xquik to AI-Powered Automation Platforms.
- Describe its REST API, MCP server, HMAC webhooks, and monitoring.
- Add the required independent-service and trademark disclosure.
- Keep one signed commit on the current default branch.

## Independent Repository Fix

Remove the retired Automate.io listing. Its URL redirects to Notion and no longer represents the named product.

## Validation

- The Xquik listing appears exactly once.
- Its description contains no volatile tool or endpoint count.
- The Xquik homepage resolves with HTTP 200.
- Automate.io redirects to `https://www.notion.com/`.
- The retired listing is absent.
- `git diff --check` passed.
- The focused diff contains 4 additions and 2 deletions.

Disclosure: I work on Xquik.

Xquik is an independent third-party service. Not affiliated with X Corp. "Twitter" and "X" are trademarks of X Corp.
