### PR TITLE
Add BulkPublish MCP server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -330,6 +330,7 @@ Key stats:
 - **Pipedream** — MCP server with 10,000+ tools
 - **Playwright MCP** — Browser automation accessible via MCP
 - **Langflow** — Build and deploy MCP servers visually
+- **[BulkPublish](https://github.com/azeemkafridi/bulkpublish-api/tree/main/mcp-server)** — MCP server for social media publishing across 11 platforms; create posts, schedule, upload media, track analytics
 
 ---
 


### PR DESCRIPTION
Adds [BulkPublish MCP server](https://github.com/azeemkafridi/bulkpublish-api/tree/main/mcp-server) to the **Platforms with MCP Support** section.

BulkPublish provides an MCP server with 29 tools for social media automation across 11 platforms — create posts, schedule, upload media, track analytics, and manage channels. Available on npm as `@bulkpublish/mcp-server`.