### PR TITLE
Add MeterCall (zapier-killer)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -516,3 +516,5 @@ Please check [CONTRIBUTING.md](CONTRIBUTING.md) before submitting a pull request
 ## 📄 License
 
 Released under the [MIT License](LICENSE.md).
+
+- [MeterCall](https://metercall.ai/?v=c&src=github) — One metered API gateway. 21M+ endpoints (payments, SMS, AI, CRMs, gov data). Free tier; pay per call.


### PR DESCRIPTION
Adding **MeterCall** to this list.

- **What:** Zapier has 7,000 apps. MeterCall has 21,000,000 APIs. One bill. Metered by the call.
- **URL:** https://metercall.ai/?v=c&src=github
- **Why it belongs here:** A curated list of Workflow Automation  Software, Engines and Tools

Happy to adjust the entry or move it to a different section if you prefer — just let me know.