### PR TITLE
Add Bernstein to Multi-Agent Orchestration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -185,6 +185,8 @@ Key stats:
 
 > Code-first frameworks for building systems where multiple AI agents collaborate.
 
+- **[Bernstein](https://github.com/sipyourdrink-ltd/bernstein)** — Deterministic Python orchestrator for CLI coding agents. Coordinates 37 agents (Claude Code, Codex CLI, Gemini CLI, OpenHands, Aider, Amp, Goose, and more) running in parallel git worktrees. File-based state, MCP server, quality gates, cost tracking with budgets. Apache 2.0.
+
 - **[CrewAI](https://github.com/crewAIInc/crewAI)** ⭐ 32K+ stars — Role-based multi-agent framework. Agents collaborate like a team, each with a defined role. Minimal setup, works without LangChain. Popular for customer service and marketing automation.
 
 - **[LangChain](https://github.com/langchain-ai/langchain)** ⭐ 90K+ stars — The foundational LLM framework. Tools, memory, retrieval, agents, chains. Vast ecosystem and wide adoption.

--- a/readme.md
+++ b/readme.md
@@ -185,7 +185,7 @@ Key stats:
 
 > Code-first frameworks for building systems where multiple AI agents collaborate.
 
-- **[Bernstein](https://github.com/sipyourdrink-ltd/bernstein)** — Deterministic Python orchestrator for CLI coding agents. Coordinates 40+ agents (Claude Code, Codex CLI, Gemini CLI, OpenHands, Aider, Amp, Goose, and more) running in parallel git worktrees. File-based state, MCP server, quality gates, cost tracking with budgets. Apache 2.0.
+- **[Bernstein](https://github.com/sipyourdrink-ltd/bernstein)** — Open-source governance layer for AI agents, built on a deterministic Python scheduler. Coordinates 40+ agents (Claude Code, Codex CLI, Gemini CLI, OpenHands, Aider, Amp, Goose, and more) running in parallel git worktrees. File-based state, MCP server, quality gates, cost tracking with budgets. Apache 2.0.
 
 - **[CrewAI](https://github.com/crewAIInc/crewAI)** ⭐ 32K+ stars — Role-based multi-agent framework. Agents collaborate like a team, each with a defined role. Minimal setup, works without LangChain. Popular for customer service and marketing automation.
 

--- a/readme.md
+++ b/readme.md
@@ -185,7 +185,7 @@ Key stats:
 
 > Code-first frameworks for building systems where multiple AI agents collaborate.
 
-- **[Bernstein](https://github.com/sipyourdrink-ltd/bernstein)** — Deterministic Python orchestrator for CLI coding agents. Coordinates 37 agents (Claude Code, Codex CLI, Gemini CLI, OpenHands, Aider, Amp, Goose, and more) running in parallel git worktrees. File-based state, MCP server, quality gates, cost tracking with budgets. Apache 2.0.
+- **[Bernstein](https://github.com/sipyourdrink-ltd/bernstein)** — Deterministic Python orchestrator for CLI coding agents. Coordinates 40+ agents (Claude Code, Codex CLI, Gemini CLI, OpenHands, Aider, Amp, Goose, and more) running in parallel git worktrees. File-based state, MCP server, quality gates, cost tracking with budgets. Apache 2.0.
 
 - **[CrewAI](https://github.com/crewAIInc/crewAI)** ⭐ 32K+ stars — Role-based multi-agent framework. Agents collaborate like a team, each with a defined role. Minimal setup, works without LangChain. Popular for customer service and marketing automation.
 


### PR DESCRIPTION
Adds Bernstein under **Agent Frameworks & Dev Libraries → Multi-Agent Orchestration**.

[Bernstein](https://github.com/sipyourdrink-ltd/bernstein) is an open-source governance layer for AI agents, built on a deterministic Python scheduler. It coordinates 40+ CLI coding agents (Claude Code, Codex CLI, Gemini CLI, OpenHands, Aider, Amp, Goose, Qwen, Ollama, GitHub Copilot CLI, and more) running in parallel git worktrees, with file-based state in `.sdd/`, a first-class MCP server, quality gates, and cost tracking with budgets.

Why it fits this section: it is a code-first framework for building systems where multiple AI agents collaborate, with the scheduling, worktree isolation, and quality gates supplied by the framework itself.

- License: Apache 2.0
- Repo: https://github.com/sipyourdrink-ltd/bernstein
- Website: https://bernstein.run
- Disclosure: I am a maintainer.

Submission checklist:
- [x] Workflow automation tool
- [x] One suggestion per PR
- [x] Format: `[RESOURCE](LINK) - DESCRIPTION.`
- [x] Capitalized title
- [x] Inserted alphabetically (Bernstein → B, before CrewAI)
