### PR TITLE
Add Nylas CLI under Specialized Agent Libraries

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,8 @@ Key stats:
 
 - **[ZenML](https://github.com/zenml-io/zenml)** — MLOps + LLMOps framework. Manages the production lifecycle of agents — the "outer loop" that LangChain and CrewAI leave unaddressed.
 
+- **[Nylas CLI](https://github.com/nylas/cli)** — Email, calendar, and contacts layer for AI agents. Built-in MCP server with 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via one auth flow. Gives agents a real inbox and working calendar. Install with `nylas mcp install`. Docs at https://cli.nylas.com.
+
 ---
 
 ## 🌐 Browser Automation & Computer Use


### PR DESCRIPTION
Adds Nylas CLI to the Specialized Agent Libraries subsection.

**What it is:** Email, calendar, and contacts layer for AI agents. Built-in MCP server with 16 tools across Gmail, Outlook, Exchange, Yahoo, iCloud, and IMAP via one auth flow. Gives AI agents a real inbox and working calendar.

**Why this section:** Fits alongside Mem0 (memory layer), Firecrawl (web data layer), Agno (agent framework) — specialized library that adds a missing capability (email/calendar) to AI agents.

**Source:** https://github.com/nylas/cli
**Docs:** https://cli.nylas.com
**Install:** `brew install nylas/nylas-cli/nylas` then `nylas mcp install`