### PR TITLE
Add TeamOffsite to Hosted / No-Code Agent Builders

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -163,6 +163,8 @@ Key stats:
 
 - **[Agentforce (Salesforce)](https://www.salesforce.com/agentforce/)** — Salesforce's agentic AI platform. Deploy AI agents directly inside Slack as virtual teammates.
 
+- **[TeamOffsite](https://teamoffsite.ai)** — A no-code orchestration platform for agent teams by [mercury.build](https://mercury.build). Bring your own agents — including Cursor, Claude Code, Devin, and OpenClaw — and manage them with built-in orchestration and governance.
+
 ### 🏢 Enterprise AI Automation
 
 - **[UiPath](https://www.uipath.com/)** — Leading enterprise RPA + AI platform. Combines bots, AI, and process mining at scale.


### PR DESCRIPTION
Adds **TeamOffsite** ([teamoffsite.ai](https://teamoffsite.ai)) to **AI Agent Platforms → ☁️ Hosted / No-Code Agent Builders**.

No-code platform to build and orchestrate teams of AI agents, with bring-your-own-agent support for Cursor, Claude Code, Devin, and OpenClaw under a single orchestration + governance layer — fits alongside Lindy, Relevance AI, and Stack AI.

- Single suggestion, one PR (per CONTRIBUTING.md)
- Follows the section's `**[Name](link)** — description.` format

**Disclosure:** I'm affiliated with TeamOffsite (mercury.build) — submitting our own product. Happy to adjust wording or placement.