### PR TITLE
Add Future AGI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,8 @@ Key stats:
 
 - **[ZenML](https://github.com/zenml-io/zenml)** — MLOps + LLMOps framework. Manages the production lifecycle of agents — the "outer loop" that LangChain and CrewAI leave unaddressed.
 
+- **[Future AGI](https://github.com/future-agi/future-agi)** — Open-source eval, observability, and guardrails layer for agents. 70+ eval metrics with LLM-as-judge, agent simulation, tracing, and runtime guardrails. Self-hostable.
+
 ---
 
 ## 🌐 Browser Automation & Computer Use


### PR DESCRIPTION
This PR adds Future AGI to this list in the Specialized Agent Libraries section.

Future AGI is an open-source (Apache-2.0), self-hostable platform for evaluating, tracing, and guardrailing LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.