### PR TITLE
Add Future AGI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,8 @@ Key stats:
 
 - **[ZenML](https://github.com/zenml-io/zenml)** — MLOps + LLMOps framework. Manages the production lifecycle of agents — the "outer loop" that LangChain and CrewAI leave unaddressed.
 
+- **[Future AGI](https://github.com/future-agi/future-agi)** — Open-source eval, observability, and guardrails layer for agents. 70+ eval metrics with LLM-as-judge, agent simulation, tracing, and runtime guardrails. Self-hostable.
+
 ---
 
 ## 🌐 Browser Automation & Computer Use


### PR DESCRIPTION
This PR adds FutureAGI to the Specialized Agent Libraries section.

FutureAGI is an open-source platform for building reliable AI agents. Simulate against personas, trace every step with OTel-native instrumentation, evaluate across 70+ metrics, and deploy guardrails, all in one feedback loop. | Apache 2.0 | Self-hostable

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with FutureAGI.