### PR TITLE
Add One Person Company

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -475,6 +475,7 @@ Key stats:
 - 🔌 [**Awesome MCP Servers**](https://github.com/punkpeye/awesome-mcp-servers) — Community list of 500+ MCP servers
 - 📊 [**AI Coding Agent Benchmarks**](https://github.com/murataslan1/ai-agent-benchmark) — SWE-Bench leaderboard, pricing, real user reviews
 - 🤖 [**AI Agentic Frameworks Guide**](https://www.agentically.sh/ai-agentic-frameworks/) — Comprehensive framework comparison
+- 🧑‍💻 [**One Person Company**](https://onepersoncompany.com) — 317 skill guides, an SEO playbook, and AI tool comparisons for solo founders automating their business
 - 📦 [**Product Hunt: AI Agent Automation**](https://www.producthunt.com/categories/ai-agent-automation) — Latest AI agent launches
 - 🌐 [**Firecrawl Blog**](https://www.firecrawl.dev/blog) — Browser agent guides and web automation news
 


### PR DESCRIPTION
Adds **[One Person Company](https://onepersoncompany.com)** to the **Resources & Directories** section.

It's a free resource hub for solo founders and one-person businesses: **317 actionable skill guides**, a complete **SEO playbook**, and **AI tool comparisons** — all focused on growing a business without hiring a team.

It fits this list because it curates automation and AI-tool guidance for one-person businesses.

Thanks for curating this list!