### PR TITLE
Add llm-box to Self-Hosted & Local AI Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,8 @@ Key stats:
 
 - **[OpenPaw](https://github.com/daxaur/openpaw)** — Turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more. One command (`npx pawmode`) to install. No daemon, no cloud, MIT license.
 
+- **[llm-box](https://github.com/alib8b8/llm-box)** — Terminal-based AI workflow engine with YAML-driven pipelines. Supports 20+ LLM providers (DeepSeek, Qwen, GLM, Mistral, Kimi, etc.). Features a TUI for workflow management, local-first execution, and deterministic workflow results. Written in Go, single binary, no dependencies. MIT license.
+
 #### 🦞 Awesome OpenClaw Resources
 
 - **[Awesome OpenClaw Skills](https://github.com/VoltAgent/awesome-openclaw-skills)** — Community registry of 5,700+ skills for OpenClaw


### PR DESCRIPTION
## Description

Adding [llm-box](https://github.com/alib8b8/llm-box) - a terminal-based AI workflow engine with YAML-driven pipelines.

## Summary of Changes

- Added llm-box entry to the Self-Hosted & Local AI Agents section

## Why it belongs here

- **Local-first execution** - Runs entirely on your terminal, no cloud dependency, data stays private
- **YAML-driven workflows** - Deterministic, reproducible workflows with clear pipeline definitions
- **20+ LLM providers** - Supports DeepSeek, Qwen, GLM, Mistral, Kimi, and many more via OpenAI-compatible APIs
- **TUI interface** - Built with bubbletea/lipgloss for interactive workflow management
- **Single binary** - Written in Go, no dependencies, just download and run
- **MIT licensed** - Fully open source, no vendor lock-in