### PR TITLE
Add n8n Server Sizer to Resources & Directories

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -476,8 +476,9 @@ Key stats:
 - 📊 [**AI Coding Agent Benchmarks**](https://github.com/murataslan1/ai-agent-benchmark) — SWE-Bench leaderboard, pricing, real user reviews
 - 🤖 [**AI Agentic Frameworks Guide**](https://www.agentically.sh/ai-agentic-frameworks/) — Comprehensive framework comparison
 - 📦 [**Product Hunt: AI Agent Automation**](https://www.producthunt.com/categories/ai-agent-automation) — Latest AI agent launches
-- 🌐 [**Firecrawl Blog**](https://www.firecrawl.dev/blog) — Browser agent guides and web automation news
-
+- 🌐 [**Firecrawl Blog**](https://www.firecrawl.dev/blog) — Browser agent guides and web automation news 
+- 📊 [**n8n Server Sizer**](https://n8nsizer.com) — Free calculator for self-hosted n8n server specs (RAM/CPU/disk) with a docker-compose generator
+- 
 ---
 
 ## 💬 Communities

--- a/readme.md
+++ b/readme.md
@@ -477,7 +477,7 @@ Key stats:
 - 🤖 [**AI Agentic Frameworks Guide**](https://www.agentically.sh/ai-agentic-frameworks/) — Comprehensive framework comparison
 - 📦 [**Product Hunt: AI Agent Automation**](https://www.producthunt.com/categories/ai-agent-automation) — Latest AI agent launches
 - 🌐 [**Firecrawl Blog**](https://www.firecrawl.dev/blog) — Browser agent guides and web automation news
-- 📊 [**n8n Server Sizer**](https://n8nsizer.com) — Free calculator for self-hosted n8n server specs (RAM/CPU/disk) with a docker-compose generator
+- 📊 [**n8n Server Sizer**](https://n8nsizer.com/?lang=en) — Free calculator for self-hosted n8n server specs (RAM/CPU/disk) with a docker-compose generator
 - 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -476,7 +476,7 @@ Key stats:
 - 📊 [**AI Coding Agent Benchmarks**](https://github.com/murataslan1/ai-agent-benchmark) — SWE-Bench leaderboard, pricing, real user reviews
 - 🤖 [**AI Agentic Frameworks Guide**](https://www.agentically.sh/ai-agentic-frameworks/) — Comprehensive framework comparison
 - 📦 [**Product Hunt: AI Agent Automation**](https://www.producthunt.com/categories/ai-agent-automation) — Latest AI agent launches
-- 🌐 [**Firecrawl Blog**](https://www.firecrawl.dev/blog) — Browser agent guides and web automation news 
+- 🌐 [**Firecrawl Blog**](https://www.firecrawl.dev/blog) — Browser agent guides and web automation news
 - 📊 [**n8n Server Sizer**](https://n8nsizer.com) — Free calculator for self-hosted n8n server specs (RAM/CPU/disk) with a docker-compose generator
 - 
 ---


### PR DESCRIPTION
Adds n8n Server Sizer to Resources & Directories.

It's a free, no-signup web calculator that estimates the RAM/CPU/disk a self-hosted n8n instance needs based on workload, and generates a matching docker-compose file. Fits the existing resources bucket alongside the other n8n and automation tooling in the list.