### PR TITLE
Add Hellomatik

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,7 @@ Key stats:
 - **[Stack AI](https://www.stack-ai.com/)** — Visual builder → internal app or API. Templates for support, sales, policy Q&A. Enterprise governance with role-based access and audit history.
 
 - **[Agentforce (Salesforce)](https://www.salesforce.com/agentforce/)** — Salesforce's agentic AI platform. Deploy AI agents directly inside Slack as virtual teammates.
+- **[Hellomatik](https://hellomatik.com)** — AI agent platform that turns company knowledge into agents that answer, sell and book across WhatsApp, email and web.
 
 ### 🏢 Enterprise AI Automation
 


### PR DESCRIPTION
Adds **Hellomatik** — an AI agent platform that turns a company's own knowledge into agents that answer, sell and book across WhatsApp, email and web (integrations: Shopify, Stripe, Sage). Single entry matched to the section format. Thanks for maintaining the list!