### PR TITLE
Add Autoposting to Classic Automation &amp; iPaaS

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,7 @@ Key stats:
 - **[Tallyfy](https://tallyfy.com/)** — *[Review](https://productivity.directory/tallyfy)* — Automate workflows, approvals, and SOPs for teams.
 
 - **[Kissflow](https://kissflow.com/)** — Low-code platform with AI natural language workflow creation and predictive workflow optimization.
+- [Autoposting](https://autoposting.ai) — AI social media manager: generates posts in your own voice, clips long video, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ Key stats:
 - **[Tallyfy](https://tallyfy.com/)** — *[Review](https://productivity.directory/tallyfy)* — Automate workflows, approvals, and SOPs for teams.
 
 - **[Kissflow](https://kissflow.com/)** — Low-code platform with AI natural language workflow creation and predictive workflow optimization.
-- [Autoposting](https://autoposting.ai) — AI social media manager: generates posts in your own voice, clips long video, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube
+- **[Autoposting](https://autoposting.ai/)** — AI social media automation that writes posts in your voice, clips long video, and schedules across five networks.
 
 ---
 


### PR DESCRIPTION
Adds [Autoposting](https://autoposting.ai) under Classic Automation & iPaaS.

Automates the social publishing workflow end to end: generates posts in your own voice, clips long video into short-form, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube. Also exposes a remote MCP server for agent-driven workflows.

One line added, bold-link and en-dash style matching the section.