### PR TITLE
Add n8n Uptime Ping Alert

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -501,6 +501,7 @@ Key stats:
 - [**r/ClaudeAI**](https://www.reddit.com/r/ClaudeAI/)
 - [**Cursor Forum**](https://forum.cursor.com/)
 - [**Cline Community**](https://www.reddit.com/r/cline/)
+- [n8n Uptime Ping Alert](https://github.com/DeusAcc/n8n-uptime-ping-alert) - Free n8n workflow that checks a site every 5 minutes and alerts on Telegram only on state change.
 
 ---
 


### PR DESCRIPTION
Adding a free, open-source n8n workflow (n8n Uptime Ping Alert) that fits this list.

The repo README documents usage and also links to a paid bundle at https://negozio.mooo.com/?src=dariubs-awesome-workflow-automation — the specific workflow linked here is itself free (no account/paywall).

Happy to adjust placement/wording if it doesn't fit.