### PR TITLE
Add n8n-uptime-ping-alert

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -376,6 +376,7 @@ Key stats:
 ---
 
 ## 🗺️ Visual Mapping & Diagramming
+- [n8n-uptime-ping-alert](https://github.com/DeusAcc/n8n-uptime-ping-alert) - Free n8n workflow that checks a site every 5 minutes and alerts on Telegram only on state change (up/down).
 
 - **[Lucidchart](https://www.lucidchart.com/)** — *[Review](https://productivity.directory/lucidchart)* — Visual workflow mapping, flowcharts, and diagramming. AI-assisted diagram generation.
 


### PR DESCRIPTION
Adds n8n-uptime-ping-alert, a free, open-source n8n workflow relevant to this list.

Disclosure: I'm the author of this project.