### PR TITLE
Add Orkas to Local AI Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -132,13 +132,15 @@ Key stats:
 
 > Run on your own machine. Private, always-on, multi-channel. This is where personal AI automation is headed.
 
+- **[GhostClaw](https://github.com/b1rdmania/ghostclaw)** — An AI agent that lives on your computer and works for you. Message it on Telegram like a co-worker. Reads email, does research, runs scheduled tasks. Built on Claude Code + Agent SDK. No containers, no cloud. 10 minutes to set up. MIT license.
+
 - **[OpenClaw](https://github.com/openclaw/openclaw)** ⭐ — Your own personal AI assistant. Runs locally on any OS. Connects to WhatsApp, Telegram, Slack, Discord, Signal, iMessage, Microsoft Teams, Matrix, and more. Uses natural language — no predefined workflows needed. Features browser control, cron jobs, voice via ElevenLabs, multi-agent routing, Canvas workspace, and a public skill registry ([ClawHub](https://github.com/VoltAgent/awesome-openclaw-skills)) with 5,700+ community skills. Privacy-first. MIT license.
 
-- **[GhostClaw](https://github.com/b1rdmania/ghostclaw)** — An AI agent that lives on your computer and works for you. Message it on Telegram like a co-worker. Reads email, does research, runs scheduled tasks. Built on Claude Code + Agent SDK. No containers, no cloud. 10 minutes to set up. MIT license.
+- **[OpenPaw](https://github.com/daxaur/openpaw)** — Turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more. One command (`npx pawmode`) to install. No daemon, no cloud, MIT license.
 
 - **[Openwork](https://github.com/accomplish-ai/openwork)** — MIT-licensed open alternative to Anthropic's Cowork with multi-LLM support for browser automation.
 
-- **[OpenPaw](https://github.com/daxaur/openpaw)** — Turns Claude Code into a personal assistant with 38 skills — email, calendar, Spotify, smart home, Slack, GitHub, and more. One command (`npx pawmode`) to install. No daemon, no cloud, MIT license.
+- **[Orkas](https://github.com/Orkas-AI/Orkas)** — Open-source, local-first desktop AI workforce coordinated by a Commander through one chat.
 
 #### 🦞 Awesome OpenClaw Resources
 


### PR DESCRIPTION
Adds Orkas to **Self-Hosted & Local AI Agents** as an MIT-licensed desktop workspace for coordinating agent teams. The surrounding entries are ordered alphabetically per the contribution guide.

Validation: `git diff --check` passed and the canonical GitHub link resolves.