### PR TITLE
Add agent-qa to AI Browser Agents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -253,6 +253,8 @@ Key stats:
 
 ### AI Browser Agents
 
+- **[agent-qa](https://github.com/vostride/agent-qa)** ⭐ 768 stars — Self-improving QA agent for natural-language web/mobile regression tests, with persistent execution memory, Playwright/Appium runners, a CLI, MCP, and Agent Skills.
+
 - **[Browser-Use](https://github.com/browser-use/browser-use)** ⭐ 60K+ stars — Open-source Python library. Makes websites accessible to AI agents using a DOM + Vision hybrid approach. Works with Claude, GPT, Gemini, and local Ollama models. MIT license.
 
 - **[Skyvern](https://github.com/Skyvern-AI/skyvern)** ⭐ 10K+ stars — Vision LLM-based browser automation. Playwright-compatible SDK plus a no-code workflow builder. Best for form fills, logins, downloads, and RPA-style tasks.


### PR DESCRIPTION
## Summary

Adds agent-qa to **AI Browser Agents**. It provides a repeatable QA workflow for software teams: author web/mobile regression tests in natural language, run them through Playwright or Appium, retain execution memory, and let coding agents consume the loop through CLI, MCP, or Agent Skills.

## Validation

- One resource added in alphabetical order and the existing list format
- Current GitHub star count recorded at submission time: 768
- Repository was not already listed or proposed
- `git diff --check` passes

Project disclosure: this submission is for agent-qa itself. Its current FSL-1.1-ALv2 license converts to Apache-2.0 after two years.
