### PR TITLE
Add CapMonster Cloud to Browser Infrastructure

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -275,6 +275,8 @@ Key stats:
 
 - **[Hyperbrowser](https://hyperbrowser.ai/)** — AI-native browser platform combining natural language commands with Playwright reliability. YC-backed.
 
+- **[CapMonster Cloud](https://capmonster.cloud/)** — Cloud-based CAPTCHA solving API and open-source SDKs for browser agents and automation pipelines. Resolves reCAPTCHA, hCaptcha, and Cloudflare Turnstile inside Playwright, Puppeteer, and Selenium workflows.
+
 ---
 
 ## 💻 AI Coding Agents & IDEs


### PR DESCRIPTION
### Summary
Add CapMonster Cloud to the `Browser Automation & Computer Use -> Browser Infrastructure` section.

### Details
- **Entry:** `**[CapMonster Cloud](https://capmonster.cloud/en)** — Cloud-based CAPTCHA solving API and open-source SDKs for browser agents and automation pipelines. Resolves reCAPTCHA, hCaptcha, and Cloudflare Turnstile inside Playwright, Puppeteer, and Selenium workflows.`
- **Placement:** Positioned alphabetically between `Browserbase` and `Hyperbrowser`.
- **Relevance:** Essential infrastructure component for AI browser agents and automation pipelines requiring automated challenge bypass (Cloudflare Turnstile, reCAPTCHA, hCaptcha). Open-source SDKs are available under MIT license.