### PR TITLE
Add PostWire to Platforms with MCP Support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -334,6 +334,7 @@ Key stats:
 - **Pipedream** — MCP server with 10,000+ tools
 - **Playwright MCP** — Browser automation accessible via MCP
 - **Langflow** — Build and deploy MCP servers visually
+- **PostWire** — MCP server for publishing: one tool call posts to TikTok, Instagram, YouTube, LinkedIn, X, Bluesky, Mastodon, Telegram and Discord ([postwire.io](https://postwire.io))
 
 ---
 


### PR DESCRIPTION
Adds PostWire to the MCP section.

It is an MCP server for the publishing side of automation: one tool call posts to TikTok, Instagram, YouTube, LinkedIn, X, Bluesky, Mastodon, Telegram and Discord, with a scheduling queue. Useful in these workflows because the platform approvals (TikTok Content Posting audit, Meta app review) are already granted, which is normally the slow part of building this yourself.

Also on npm as postwire-mcp and in the official MCP registry.