### PR TITLE
Add Orch8 to Workflow Orchestration Tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -353,6 +353,8 @@ Key stats:
 
 - **[Kestra](https://kestra.io/)** — Open-source declarative workflow orchestration. YAML-based, 500+ plugins, cloud-native.
 
+- **[Orch8](https://orch8.io/)** — Self-hosted durable workflow engine written in Rust. Runs declarative long-running workflows with persistent execution, retries, checkpoints, rate limits, and human approvals.
+
 - **[Apache Kafka](https://kafka.apache.org/)** — Distributed event streaming platform. Foundation for real-time data pipelines and event-driven automation.
 
 ---


### PR DESCRIPTION
## Summary

Adds [Orch8](https://orch8.io/) to Data Pipeline & Workflow Orchestration.

Orch8 is a self-hosted durable workflow engine written in Rust. It runs declarative long-running workflows with persistent execution, retries, checkpoints, rate limits, and human approval steps.

## Fit

- Workflow automation and orchestration is the primary product category
- The project is actively maintained and has tagged releases
- Documentation and source are available at https://github.com/orch8-io/engine
- Current license is BUSL-1.1, converting to Apache-2.0 after four years

I searched existing entries, issues, and pull requests for duplicates before submitting.