### PR TITLE
Add Drevon

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,8 @@ Key stats:
 
 - **[Dreamlit AI](https://dreamlit.ai/)** — AI email agent that turns database events into automated email workflows.
 
+- **[Drevon](https://drevon.dev)** — Console for GTM engineers where AI agents automate prospecting, signal tracking, account research, and inbound qualification, replacing the manual research work GTM teams do by hand. Ships with a native browser using your own LinkedIn, Sales Nav, and X logins, connects the rest of your GTM stack over MCP, and works for individuals, teams, or self-hosted enterprise deployments.
+
 - **[Sintra AI](https://sintra.ai/)** — A team of specialized AI helpers for marketing, customer support, sales, recruiting, and data analysis.
 
 - **[Wordware](https://www.wordware.ai/)** — AI agent builder using natural language. Teams can build and share agents without writing code.


### PR DESCRIPTION
Adds Drevon (https://drevon.dev) to the AI-Powered Automation Platforms section.

Drevon is a console for GTM engineers: AI agents run evidence-backed prospecting, signal tracking, account research, and inbound qualification, automating the manual research work GTM teams otherwise do by hand. It ships with a native browser that uses the user's own LinkedIn, Sales Navigator, and X logins, connects the rest of a GTM stack over MCP, and supports individuals, teams, or self-hosted enterprise deployments.

This fits the list's scope as a workflow automation tool that automates a specific, well-defined GTM research workflow rather than a general-purpose AI assistant, following the format and alphabetical ordering in CONTRIBUTING.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)